### PR TITLE
Fix(datasource): Solve the problem that the test connection takes too long when the MySQL data source tests the connection, and the ip or port input is wrong.

### DIFF
--- a/chat2db-server/chat2db-spi/src/main/java/ai/chat2db/spi/sql/IDriverManager.java
+++ b/chat2db-server/chat2db-spi/src/main/java/ai/chat2db/spi/sql/IDriverManager.java
@@ -75,6 +75,8 @@ public class IDriverManager {
         if (url == null) {
             throw new SQLException("The url cannot be null", "08001");
         }
+        // 设置超时时间为7s
+        DriverManager.setLoginTimeout(7);
         DriverManager.println("DriverManager.getConnection(\"" + url + "\")");
         SQLException reason = null;
         DriverEntry driverEntry = DRIVER_ENTRY_MAP.get(driver.getName());


### PR DESCRIPTION
When adding or editing MySQL data sources, if there is an error in ip or port, it will take a long time to test the connection. You can set a timeout to shorten this time.