### PR TITLE
Changes for Issue 1360

### DIFF
--- a/chat2db-server/chat2db-server-domain/chat2db-server-domain-core/src/main/java/ai/chat2db/server/domain/core/impl/DatabaseServiceImpl.java
+++ b/chat2db-server/chat2db-server-domain/chat2db-server-domain-core/src/main/java/ai/chat2db/server/domain/core/impl/DatabaseServiceImpl.java
@@ -118,9 +118,10 @@ public class DatabaseServiceImpl implements DatabaseService {
                             ThreadUtil.execute(() -> {
                                 try {
                                     database.setSchemas(metaData.schemas(connection, database.getName()));
-                                    countDownLatch.countDown();
                                 } catch (Exception e) {
                                     log.error("queryDatabaseSchema error", e);
+                                } finally{
+                                    countDownLatch.countDown();
                                 }
                             });
                         }

--- a/chat2db-server/chat2db-server-tools/chat2db-server-tools-common/src/main/java/ai/chat2db/server/tools/common/util/EasyStringUtils.java
+++ b/chat2db-server/chat2db-server-tools/chat2db-server-tools-common/src/main/java/ai/chat2db/server/tools/common/util/EasyStringUtils.java
@@ -26,7 +26,7 @@ public class EasyStringUtils {
      * @return modified job number
      */
     public static String cutUserId(String userId) {
-        if (!org.apache.commons.lang3.StringUtils.isNumeric(userId)) {
+        if (!StringUtils.isNumeric(userId)) {
             return userId;
         }
         int startIndex = 0;


### PR DESCRIPTION
修復以下用例
如果在方法「queryDatabaseSchema」中設定架構時發生異常，則不會為該執行緒呼叫 countDown()，從而導致「countDownLatch.await()」出現死鎖情況