### PR TITLE
fix:1656 自定义AIOpenrouter无法使用

### DIFF
--- a/chat2db-client/src/blocks/Setting/AiSetting/index.tsx
+++ b/chat2db-client/src/blocks/Setting/AiSetting/index.tsx
@@ -54,9 +54,9 @@ export default function SettingAI(props: IProps) {
   /** 应用Ai配置 */
   const handleApplyAiConfig = () => {
     const newAiConfig = { ...aiConfig };
-    if (newAiConfig.apiHost && !newAiConfig.apiHost?.endsWith('/')) {
+    /*if (newAiConfig.apiHost && !newAiConfig.apiHost?.endsWith('/')) {
       newAiConfig.apiHost = newAiConfig.apiHost + '/';
-    }
+    }*/
     if (aiConfig?.aiSqlSource === AIType.CHAT2DBAI) {
       newAiConfig.apiHost = `${window._appGatewayParams.baseUrl || 'http://test.sqlgpt.cn/gateway'}${'/model/'}`;
     }


### PR DESCRIPTION
apihost默认不在结尾加/，以用户输入为准。